### PR TITLE
Develop

### DIFF
--- a/VitLib/file_utils.py
+++ b/VitLib/file_utils.py
@@ -31,7 +31,7 @@ def get_file_paths(path: str) -> list[str]:
     """
     folder_path = pathlib.Path(path)
     file_paths = list(folder_path.glob('*'))
-    return [str(path) for path in file_paths]
+    return [str(path).replace('\\', '/') for path in file_paths]
 
 def get_file_names(path: str) -> list[str]:
     """フォルダ内のファイル名をすべて取得する関数

--- a/VitLib/image_processing.py
+++ b/VitLib/image_processing.py
@@ -23,7 +23,7 @@ def change_hue(img:np.ndarray, hue_degree:int) -> np.ndarray:
         hue_degree (int): 色相の変更量(0~180)
 
     Returns:
-        list: 色相が変更された画像リスト
+        numpy.ndarray: 色相が変更された画像
     """
     img = cv2.cvtColor(img, cv2.COLOR_BGR2HSV)
     img[:,:,0] = (img[:,:,0]+hue_degree)%180
@@ -151,8 +151,10 @@ def random_cut_image(img_list:list, size:tuple) -> list:
     
     Args:
         img_list (list): 画像リスト
-        top_left_range (tuple): 切り取りの左上の座標の範囲
         size (tuple): 切り取りのサイズ
+    
+    Returns:
+        list: 切り取られた画像リスト
     """
     img_size = img_list[0].shape
     top_left = (np.random.randint(0, img_size[0]-size[0]), np.random.randint(0, img_size[1]-size[1]))
@@ -166,6 +168,9 @@ def select_cut_image(img_list:list, top_left:tuple, size:tuple) -> list:
         img_list (list): 画像リスト
         top_left (tuple): 切り取りの左上の座標
         size (tuple): 切り取りのサイズ
+    
+    Returns:
+        list: 切り取られた画像リスト
     """
     return [cut_image(img, top_left, size) for img in img_list]
 
@@ -196,7 +201,6 @@ def random_rotate_image(img_list:list) -> list:
 
     Args:
         img_list (list): 画像リスト
-        rotate_times_range (tuple): 回転回数の範囲(1回転につき90度)
 
     Returns:
         list: 回転された画像リスト

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ def get_ext_module(use_openmp:bool):
 def get_setup_kwargs(use_openmp:bool):
     setup_kwargs = {
         "name": "VitLib",
-        "version": "3.1.1",
+        "version": "3.2.0",
         "description": "A fast and accurate image processing library for cell image analysis.",
         "author": "Kotetsu0000",
         'ext_modules': get_ext_module(use_openmp),


### PR DESCRIPTION
This pull request includes several changes to improve the functionality and documentation of the `VitLib` library. The most important changes involve fixing file path formatting, updating function return types, and adding missing return type documentation. Additionally, the library version has been updated.

### File Path Formatting:
* [`VitLib/file_utils.py`](diffhunk://#diff-c980e10ba08f15d30b4ad4dd8383a2acc2f2543caa36419372a58a54e87adce5L34-R34): Modified the `get_file_paths` function to replace backslashes with forward slashes in file paths.

### Function Return Types:
* [`VitLib/image_processing.py`](diffhunk://#diff-a968fe7c30cfffe9be5bd49e175aa3f97e7bc4d9520cd80a1967509278be58b7L26-R26): Updated the return type of the `change_hue` function to `numpy.ndarray`.

### Documentation Improvements:
* [`VitLib/image_processing.py`](diffhunk://#diff-a968fe7c30cfffe9be5bd49e175aa3f97e7bc4d9520cd80a1967509278be58b7L154-R157): Added missing return type documentation for the `random_cut_image` function.
* [`VitLib/image_processing.py`](diffhunk://#diff-a968fe7c30cfffe9be5bd49e175aa3f97e7bc4d9520cd80a1967509278be58b7R171-R173): Added missing return type documentation for the `select_cut_image` function.

### Version Update:
* [`setup.py`](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L75-R75): Updated the library version from `3.1.1` to `3.2.0`.