### PR TITLE
Improve docstrings for threshold and area detection functions

### DIFF
--- a/VitLib/VitLib_cython/common.pyx
+++ b/VitLib/VitLib_cython/common.pyx
@@ -173,8 +173,6 @@ cpdef cnp.ndarray[cnp.uint64_t, ndim=1] detect_deleted_area_candidates_old(cnp.n
 
     Args:
         img (np.ndarray): 2値画像 (画素値: 0 またはその他)
-        min_area (int): 最小面積の閾値
-        max_area (int, optional): 最大面積の閾値 (Noneの場合は制限なし)
 
     Returns:
         np.ndarray: 小領域の面積リスト
@@ -255,7 +253,7 @@ cpdef cnp.ndarray[cnp.int32_t, ndim=1] detect_deleted_area_candidates(cnp.ndarra
 @cython.boundscheck(False)
 @cython.wraparound(False)
 cpdef cnp.ndarray[DTYPE_t, ndim=1] extract_threshold_values_old(cnp.ndarray[DTYPE_t, ndim=2] img):
-    """画像から閾値を抽出する.
+    """グレースケール画像から閾値のリストを抽出する関数
     
     Args:
         img (np.ndarray): グレースケール画像
@@ -283,7 +281,7 @@ cpdef cnp.ndarray[DTYPE_t, ndim=1] extract_threshold_values_old(cnp.ndarray[DTYP
 @cython.boundscheck(False)
 @cython.wraparound(False)
 cpdef cnp.ndarray[DTYPE_t, ndim=1] extract_threshold_values(cnp.ndarray[DTYPE_t, ndim=2] img, int min_th=0, int max_th=255):
-    """画像から閾値候補を抽出する関数
+    """グレースケール画像から閾値のリストを抽出する関数
 
     Args:
         img (np.ndarray): グレースケール画像

--- a/VitLib/VitLib_python/common.py
+++ b/VitLib/VitLib_python/common.py
@@ -77,7 +77,7 @@ def detect_deleted_area_candidates(img: np.ndarray, min_area: int = 0, max_area:
     return np.unique(stats)
 
 def extract_threshold_values(img: np.ndarray, min_th: int = 0, max_th: int = 255) -> np.ndarray:
-    """画像から閾値候補を抽出する関数
+    """グレースケール画像から閾値のリストを抽出する関数
 
     Args:
         img (np.ndarray): グレースケール画像


### PR DESCRIPTION
This pull request includes changes to improve the clarity of function docstrings in the `VitLib` library. The modifications ensure that the descriptions are more specific and accurate.

Improvements to docstrings:

* [`VitLib/VitLib_cython/common.pyx`](diffhunk://#diff-1c451f7e695bc152b823b2aa22e63602cd85c4cbb55b4b4fd355a8dbd405e0d9L258-R256): Updated the docstring for `extract_threshold_values_old` to specify that it extracts a list of thresholds from grayscale images.
* [`VitLib/VitLib_cython/common.pyx`](diffhunk://#diff-1c451f7e695bc152b823b2aa22e63602cd85c4cbb55b4b4fd355a8dbd405e0d9L286-R284): Updated the docstring for `extract_threshold_values` to specify that it extracts a list of thresholds from grayscale images.
* [`VitLib/VitLib_python/common.py`](diffhunk://#diff-accf828f2944ca2c0518ac1a26c2cc17e7a81763d1ee0fb7b473193c49b7e32cL80-R80): Updated the docstring for `extract_threshold_values` to specify that it extracts a list of thresholds from grayscale images.- Updated docstrings in common.pyx and common.py for extract_threshold_values and detect_deleted_area_candidates functions
- Clarified function descriptions to be more precise about input and output
- Removed unnecessary parameter descriptions
- Maintained consistent documentation style across Cython and Python implementations